### PR TITLE
Remove superfluous call ensure_update_center_present to update center

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -60,7 +60,6 @@ EOH
     def executor
       wait_until_ready!
       ensure_cli_present!
-      ensure_update_center_present!
 
       options = {}.tap do |h|
         h[:cli]      = cli


### PR DESCRIPTION
The call is currently called before managing plugins, which is the only place it appears to be needed. This means that we don't download on nodes that are not Jenkins masters, where it is not needed