### PR TITLE
Increase the number of open files for Jenkins slaves

### DIFF
--- a/templates/default/sv-jenkins-slave-run.erb
+++ b/templates/default/sv-jenkins-slave-run.erb
@@ -7,7 +7,7 @@
 
 exec 2>&1
 cd <%= @options[:new_resource].remote_fs %>
-exec chpst -u <%= @options[:new_resource].user %> \
+exec chpst -o 32768 -u <%= @options[:new_resource].user %> \
   env HOME=<%= @options[:new_resource].remote_fs %> \
   JENKINS_HOME=<%= @options[:new_resource].remote_fs %> \
   <%= @options[:java_bin] %> \


### PR DESCRIPTION
This is the only location where we are able to change `ulimit -n` for a slave.
Making this Criteo-specific because it is unlikely this will make it upstream.