### PR TITLE
Apply changes from criteo-forks to catchup with upstream

### DIFF
--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -60,4 +60,11 @@ default['jenkins']['executor'].tap do |executor|
   # CLI user to pass for ssh/https protocol
   #
   # executor['cli_user'] = 'example_chef_user'
+
+  # The limits for the Java process running the slave process.
+  # Example to configure the maximum number of open file descriptors:
+  #
+  #   node.set['jenkins']['executor']['ulimits'] = { 'n' => 8192 }
+  #
+  executor['ulimits'] = nil
 end

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -222,6 +222,13 @@ default['jenkins']['master'].tap do |master|
   master['ulimits'] = nil
 
   #
+  # Repository URL. Default is latest
+  #
+  #   node.set['jenkins']['master']['ulimits'] = { 'n' => 8192 }
+  #
+  master['ulimits'] = nil
+
+  #
   # Repository URL and key. Default is stable.
   #
   master['repository'], master['repository_key'] =

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -73,7 +73,7 @@ module Jenkins
       command << options[:jvm_options].to_s if options[:jvm_options]
       command << %(-jar "#{options[:cli]}")
       command << %(-s #{URI.escape(options[:endpoint])}) if options[:endpoint]
-      command << %(-#{options[:protocol]})             if options[:protocol]
+      command << %(-#{options[:protocol]})               if options[:protocol]
       command << %(-user "#{options[:cli_user]}")        if options[:cli_user]
       command << %(-i "#{options[:key]}")                if options[:key]
       command << %(-p #{uri_escape(options[:proxy])})    if options[:proxy]

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -73,7 +73,7 @@ module Jenkins
       command << options[:jvm_options].to_s if options[:jvm_options]
       command << %(-jar "#{options[:cli]}")
       command << %(-s #{URI.escape(options[:endpoint])}) if options[:endpoint]
-      command << %(-"#{options[:protocol]}")             if options[:protocol]
+      command << %(-#{options[:protocol]})             if options[:protocol]
       command << %(-user "#{options[:cli_user]}")        if options[:cli_user]
       command << %(-i "#{options[:key]}")                if options[:key]
       command << %(-p #{uri_escape(options[:proxy])})    if options[:proxy]

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -127,38 +127,6 @@ EOH
     end
 
     #
-    # A Groovy snippet that will set the requested local Groovy variable
-    # to an instance of the credentials represented by `secret`.
-    # Returns the Groovy `null` if no credentials are found.
-    #
-    # @param [String] secret
-    # @param [String] description
-    # @param [String] groovy_variable_name
-    # @return [String]
-    #
-    def credentials_for_secret_groovy(secret, description, groovy_variable_name)
-      <<-EOH.gsub(/ ^{8}/, '')
-        import jenkins.model.Jenkins;
-        import hudson.util.Secret;
-        import com.cloudbees.plugins.credentials.CredentialsProvider
-        import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
-        import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-
-        available_credentials =
-          CredentialsProvider.lookupCredentials(
-            StringCredentials.class,
-            Jenkins.getInstance(),
-            hudson.security.ACL.SYSTEM
-          ).findAll({
-            it.secret      == new Secret(#{convert_to_groovy(secret)}) &&
-            it.description == #{convert_to_groovy(description)}
-          })
-
-        #{groovy_variable_name} = available_credentials.size() > 0 ? available_credentials[0] : null
-      EOH
-    end
-
-    #
     # Helper method for converting a Ruby value to it's equivalent in
     # Groovy.
     #

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -40,6 +40,7 @@ class Chef
 
     # Attributes
     attribute :id,
+              name_attribute: true,
               kind_of: String,
               required: true
 

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -31,8 +31,7 @@ class Chef
               kind_of: String,
               name_attribute: true
     attribute :password,
-              kind_of: String,
-              required: true
+              kind_of: String
   end
 end
 

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -49,7 +49,7 @@ class Chef
         @current_resource.password(current_credentials[:password])
       end
 
-      @current_credentials
+      @current_resource
     end
 
     private

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -28,8 +28,7 @@ class Chef
 
     # Attributes
     attribute :username,
-              kind_of: String,
-              name_attribute: true
+              kind_of: String
     attribute :password,
               kind_of: String
   end

--- a/libraries/credentials_secret_file.rb
+++ b/libraries/credentials_secret_file.rb
@@ -28,7 +28,7 @@ class Chef
               default: lazy { |new_resource| "Credentials for #{new_resource.filename} - created by Chef" }
     attribute :filename,
               kind_of: String,
-              name_attribute: true
+              required: true
     attribute :data,
               kind_of: String,
               required: true
@@ -95,7 +95,7 @@ class Chef
           #{convert_to_groovy(new_resource.description)},
           new VirtualFileItem(),
           null,
-          null
+          (String)null
         )
       EOH
     end
@@ -105,8 +105,8 @@ class Chef
     #
     def fetch_existing_credentials_groovy(groovy_variable_name)
       <<-EOH.gsub(/ ^{8}/, '')
-        import jenkins.model.Jenkins;
-        import hudson.util.Secret;
+        import jenkins.model.Jenkins
+        import hudson.util.Secret
         import com.cloudbees.plugins.credentials.common.IdCredentials
         import com.cloudbees.plugins.credentials.CredentialsProvider
 
@@ -130,7 +130,8 @@ class Chef
       <<-EOH.gsub(/ ^{8}/, '')
         #{groovy_variable_name} = [
           id:credentials.id,
-          filename:credentials.filename
+          filename:credentials.fileName,
+          date:credentials.data
         ]
       EOH
     end

--- a/libraries/credentials_secret_file.rb
+++ b/libraries/credentials_secret_file.rb
@@ -1,0 +1,162 @@
+#
+# Cookbook:: jenkins
+# HWRP:: credentials_secret_file
+#
+# Author:: Dimitry Polyanitsa <d.polyanitsa@criteo.com>
+#
+# Copyright:: 2016-2017, Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'credentials'
+
+class Chef
+  class Resource::JenkinsSecretFileCredentials < Resource::JenkinsCredentials
+    attribute :description,
+              kind_of: String
+    attribute :filename,
+              kind_of: String,
+              name_attribute: true
+    attribute :data,
+              kind_of: String,
+              required: true
+  end
+end
+
+class Chef
+  class Provider::JenkinsSecretFileCredentials < Provider::JenkinsCredentials
+    use_inline_resources
+    include Jenkins::Helper
+
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsSecretFileCredentials.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.filename(current_credentials[:filename])
+        @current_resource.data(current_resource[:data])
+      end
+
+      @current_resource
+    end
+
+    private
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#credentials_groovy
+    #
+    def credentials_groovy
+      <<-EOH.gsub(/ ^{8}/, '')
+        import com.cloudbees.plugins.credentials.CredentialsScope
+        import java.nio.charset.StandardCharsets
+        import org.apache.commons.codec.binary.Base64
+        import org.apache.commons.fileupload.FileItem
+        import org.apache.commons.fileupload.FileItemHeaders
+        import org.apache.commons.lang.NotImplementedException
+        import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl
+
+        class VirtualFileItem implements FileItem {
+          String getName() { #{convert_to_groovy(new_resource.filename)} }
+          byte[] get() { Base64.decodeBase64('#{new_resource.data}') }
+
+          void delete() { throw new NotImplementedException() }
+          String getContentType() { throw new NotImplementedException() }
+          String getFieldName() { throw new NotImplementedException() }
+          InputStream getInputStream() { throw new NotImplementedException() }
+          OutputStream getOutputStream() { throw new NotImplementedException() }
+          long getSize() { throw new NotImplementedException() }
+          String getString() { throw new NotImplementedException() }
+          String getString(String encoding) { throw new NotImplementedException() }
+          boolean isFormField() { throw new NotImplementedException() }
+          boolean isInMemory() { throw new NotImplementedException() }
+          void setFieldName(String name) { throw new NotImplementedException() }
+          void setFormField(boolean state) { throw new NotImplementedException() }
+          void write(File file) { throw new NotImplementedException() }
+          FileItemHeaders getHeaders() { throw new NotImplementedException() }
+          void setHeaders(FileItemHeaders headers) { throw new NotImplementedException() }
+        }
+
+        credentials = new FileCredentialsImpl(
+          CredentialsScope.GLOBAL,
+          #{convert_to_groovy(new_resource.id)},
+          #{convert_to_groovy(new_resource.description)},
+          new VirtualFileItem(),
+          null,
+          null
+        )
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#fetch_existing_credentials_groovy
+    #
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        import jenkins.model.Jenkins;
+        import hudson.util.Secret;
+        import com.cloudbees.plugins.credentials.common.IdCredentials
+        import com.cloudbees.plugins.credentials.CredentialsProvider
+
+        available_credentials =
+          CredentialsProvider.lookupCredentials(
+            IdCredentials.class,
+            Jenkins.getInstance(),
+            hudson.security.ACL.SYSTEM
+          ).findAll({
+            it.id == #{convert_to_groovy('credentials.id')}
+          })
+
+        #{groovy_variable_name} = available_credentials.size() > 0 ? available_credentials[0] : null
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#resource_attributes_groovy
+    #
+    def resource_attributes_groovy(groovy_variable_name)
+      <<-EOH.gsub(/ ^{8}/, '')
+        #{groovy_variable_name} = [
+          id:credentials.id,
+          description:credentials.description
+        ]
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#attribute_to_property_map
+    #
+    def attribute_to_property_map
+      {
+        filename: 'credentials.fileName',
+        data: 'credentials.data',
+      }
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#correct_config?
+    #
+    def correct_config?
+      wanted_credentials = {
+        description: new_resource.description,
+        filename: new_resource.filename,
+        data: new_resource.data,
+      }
+
+      attribute_to_property_map.keys.each do |key|
+        wanted_credentials[key] = new_resource.send(key)
+      end
+    end
+  end
+end

--- a/libraries/credentials_secret_file.rb
+++ b/libraries/credentials_secret_file.rb
@@ -22,9 +22,10 @@
 require_relative 'credentials'
 
 class Chef
-  class Resource::JenkinsSecretFileCredentials < Resource::JenkinsCredentials
+  class Resource::JenkinsSecretFileCredentials < Resource::JenkinsUserCredentials
     attribute :description,
-              kind_of: String
+              kind_of: String,
+              default: lazy { |new_resource| "Credentials for #{new_resource.filename} - created by Chef" }
     attribute :filename,
               kind_of: String,
               name_attribute: true
@@ -35,9 +36,9 @@ class Chef
 end
 
 class Chef
-  class Provider::JenkinsSecretFileCredentials < Provider::JenkinsCredentials
+  class Provider::JenkinsSecretFileCredentials < Provider::JenkinsUserCredentials
     use_inline_resources
-    include Jenkins::Helper
+    provides :jenkins_secret_file_credentials
 
     def load_current_resource
       @current_resource ||= Resource::JenkinsSecretFileCredentials.new(new_resource.name)
@@ -129,7 +130,7 @@ class Chef
       <<-EOH.gsub(/ ^{8}/, '')
         #{groovy_variable_name} = [
           id:credentials.id,
-          description:credentials.description
+          filename:credentials.filename
         ]
       EOH
     end

--- a/libraries/credentials_secret_text.rb
+++ b/libraries/credentials_secret_text.rb
@@ -30,8 +30,7 @@ class Chef
 
     # Attributes
     attribute :description,
-              kind_of: String,
-              name_attribute: true
+              kind_of: String
     attribute :secret,
               kind_of: String,
               required: true
@@ -53,7 +52,7 @@ class Chef
         @current_resource.secret(current_credentials[:secret])
       end
 
-      @current_credentials
+      @current_resource
     end
 
     private
@@ -82,7 +81,7 @@ class Chef
     #
     def fetch_existing_credentials_groovy(groovy_variable_name)
       <<-EOH.gsub(/ ^{8}/, '')
-        #{credentials_for_secret_groovy(new_resource.secret, new_resource.description, groovy_variable_name)}
+        #{credentials_for_id_groovy(new_resource.id, groovy_variable_name)}
       EOH
     end
 

--- a/templates/default/sv-jenkins-slave-run.erb
+++ b/templates/default/sv-jenkins-slave-run.erb
@@ -7,6 +7,10 @@
 
 exec 2>&1
 cd <%= @options[:new_resource].remote_fs %>
+<% limits = node['jenkins']['executor']['ulimits'] %>
+<% if limits && !limits.empty? %>
+ulimit <% limits.each { |option, value| %>-<%= option %> <%= value %> <% } %>
+<% end %>
 exec chpst -u <%= @options[:new_resource].user %> \
   env HOME=<%= @options[:new_resource].remote_fs %> \
   JENKINS_HOME=<%= @options[:new_resource].remote_fs %> \

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -8,18 +8,19 @@ fixture_data_base_path = docker? ? '/opt/kitchen/data' : '/tmp/kitchen/data'
 jenkins_password_credentials 'schisamo' do
   id 'schisamo'
   description 'passwords are for suckers'
+  username 'schisamo'
   password 'superseekret'
 end
 
 # Test specifying a UUID-based ID
-jenkins_password_credentials 'schisamo2' do
-  id '63e11302-d446-4ba0-8aa4-f5821f74d36f'
+jenkins_password_credentials '63e11302-d446-4ba0-8aa4-f5821f74d36f' do
+  username 'schisamo2'
   password 'superseekret'
 end
 
 # Test specifying a string-based ID
 jenkins_password_credentials 'schisamo3' do
-  id 'schisamo3'
+  username 'schisamo3'
   password 'superseekret'
 end
 
@@ -75,4 +76,9 @@ end
 jenkins_secret_text_credentials 'dollarbills_secret' do
   id 'dollarbills_secret'
   secret '$uper$ecret'
+end
+
+jenkins_secret_file_credentials 'file1' do
+  filename 'secret_file1'
+  data 'topSecret'
 end


### PR DESCRIPTION
- New secret file credentials resource.
- Allow empty passwords.
- Apply ulimit when launching agents or master.
- Apply style fixes.
