### PR TITLE
Make integration tests for credentials creation pass

### DIFF
--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -14,14 +14,12 @@ end
 # Test specifying a UUID-based ID
 jenkins_password_credentials 'schisamo2' do
   id '63e11302-d446-4ba0-8aa4-f5821f74d36f'
-  username 'schisamo2'
   password 'superseekret'
 end
 
 # Test specifying a string-based ID
 jenkins_password_credentials 'schisamo3' do
   id 'schisamo3'
-  username 'schisamo3'
   password 'superseekret'
 end
 

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -6,6 +6,8 @@ fixture_data_base_path = '/tmp/kitchen/data'
 
 # Test basic password credentials creation
 jenkins_password_credentials 'schisamo' do
+  id 'schisamo'
+  username 'schisamo'
   description 'passwords are for suckers'
   password 'superseekret'
 end
@@ -13,23 +15,28 @@ end
 # Test specifying a UUID-based ID
 jenkins_password_credentials 'schisamo2' do
   id '63e11302-d446-4ba0-8aa4-f5821f74d36f'
+  username 'schisamo2'
   password 'superseekret'
 end
 
 # Test specifying a string-based ID
 jenkins_password_credentials 'schisamo3' do
   id 'schisamo3'
+  username 'schisamo3'
   password 'superseekret'
 end
 
 # Test basic private key credentials creation
 jenkins_private_key_credentials 'jenkins' do
+  id 'jenkins'
   description 'this is more like it'
   private_key File.read("#{fixture_data_base_path}/test_id_rsa")
 end
 
 # Test private key credentials with passphrase
 jenkins_private_key_credentials 'jenkins2' do
+  id 'jenkins2'
+  username 'jenkins2'
   private_key OpenSSL::PKey::RSA.new(File.read("#{fixture_data_base_path}/test_id_rsa_with_passphrase"), 'secret').to_pem
   passphrase 'secret'
 end
@@ -43,12 +50,14 @@ end
 
 # Test an ECDSA key without a passphrase
 jenkins_private_key_credentials 'ecdsa_nopasswd' do
+  id 'ecdsa_nopasswd'
   description 'ECDSA key passed in as string'
   private_key File.read("#{fixture_data_base_path}/test_id_ecdsa")
 end
 
 # Test an ECDSA key with a passphrase
 jenkins_private_key_credentials 'ecdsa_passwd' do
+  id 'ecdsa_passwd'
   description 'ECDSA key passed in as an object'
   private_key OpenSSL::PKey::EC.new(File.read("#{fixture_data_base_path}/test_id_ecdsa_with_passphrase"), 'secret').to_pem
   passphrase 'secret'
@@ -56,6 +65,8 @@ end
 
 # Test creating a password with a dollar sign in it
 jenkins_password_credentials 'dollarbills' do
+  id 'dollarbills'
+  username 'dollarbills'
   password '$uper$ecret'
 end
 
@@ -67,5 +78,6 @@ end
 
 # Test creating a secret text with a dollar sign in it
 jenkins_secret_text_credentials 'dollarbills_secret' do
+  id 'dollarbills_secret'
   secret '$uper$ecret'
 end

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -7,7 +7,6 @@ fixture_data_base_path = '/tmp/kitchen/data'
 # Test basic password credentials creation
 jenkins_password_credentials 'schisamo' do
   id 'schisamo'
-  username 'schisamo'
   description 'passwords are for suckers'
   password 'superseekret'
 end
@@ -36,7 +35,6 @@ end
 # Test private key credentials with passphrase
 jenkins_private_key_credentials 'jenkins2' do
   id 'jenkins2'
-  username 'jenkins2'
   private_key OpenSSL::PKey::RSA.new(File.read("#{fixture_data_base_path}/test_id_rsa_with_passphrase"), 'secret').to_pem
   passphrase 'secret'
 end
@@ -66,7 +64,6 @@ end
 # Test creating a password with a dollar sign in it
 jenkins_password_credentials 'dollarbills' do
   id 'dollarbills'
-  username 'dollarbills'
   password '$uper$ecret'
 end
 

--- a/test/integration/helpers/serverspec/support/jenkins_credentials.rb
+++ b/test/integration/helpers/serverspec/support/jenkins_credentials.rb
@@ -63,7 +63,7 @@ module Serverspec
       # key is encoded specially by Jenkins. Short of porting the
       # decryption algorithm in Ruby, we could query Jenkins for the
       # actual credentials, which would make the tests longer.
-      def has_private_key?(_private_key, passphrase = nil)
+      def has_private_key?(_private_key, _passphrase = nil)
         !(try { xml.elements['privateKeySource/privateKey'].text }).nil?
       end
 

--- a/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
+++ b/test/integration/jenkins_credentials_create/serverspec/assert_created_spec.rb
@@ -6,8 +6,9 @@ describe jenkins_user_credentials('schisamo') do
   it { should have_password('superseekret') }
 end
 
-describe jenkins_user_credentials('schisamo2') do
+describe jenkins_user_credentials('63e11302-d446-4ba0-8aa4-f5821f74d36f') do
   it { should be_a_jenkins_credentials }
+  it { should have_username('schisamo2') }
   it { should have_id('63e11302-d446-4ba0-8aa4-f5821f74d36f') }
   it { should have_password('superseekret') }
 end
@@ -20,6 +21,7 @@ end
 
 describe jenkins_user_credentials('jenkins') do
   it { should be_a_jenkins_credentials }
+  it { should have_username('jenkins') }
   it { should have_description('this is more like it') }
   it { should have_private_key(File.read("#{fixture_data_base_path}/test_id_rsa")) }
 end
@@ -30,8 +32,9 @@ describe jenkins_user_credentials('jenkins2') do
   it { should have_passphrase('secret') }
 end
 
-describe jenkins_user_credentials('jenkins3') do
+describe jenkins_user_credentials('766952b8-e1ea-4ee1-b769-e159681cb893') do
   it { should be_a_jenkins_credentials }
+  it { should have_username('jenkins3') }
   it { should have_description('I specified an ID') }
   it { should have_id('766952b8-e1ea-4ee1-b769-e159681cb893') }
   it { should have_private_key(File.read("#{fixture_data_base_path}/test_id_rsa")) }


### PR DESCRIPTION
- Settle on the 'id' attribute as the attr_name for everything, since it is
  mandatory.
- The xml method can now be shared (protected) with the parent class as it
  would be the same in every subclass.
- Reduce the scope of the private key lookup. Due to the way Jenkins stores
  its credentials, it is quite hard to replicate this logic in integration
  tests without copying it entirely. As an exercise for later, stop reading
  credentials.xml and actually query Jenkins, but this is moving towards
  functional testing.

### Description

Make us more confident that further changes in the credentials part of the cookbook do the right thing. This will be important for https://github.com/criteo-forks/jenkins/pull/9

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
