### PR TITLE
Restore smoke testing in Travis CI

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -11,7 +11,8 @@ provisioner:
   deprecations_as_errors: true
 
 verifier:
-  name: inspec
+  sudo: false
+  root_path: /opt/verifier
 
 platforms:
 - name: amazonlinux

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,10 @@ driver:
 
 provisioner:
   name: chef_zero
+  # This is to make the smoke suite run.
+  # See this open issue on JNLP slaves:
+  # https://github.com/chef-cookbooks/jenkins/issues/615
+  require_chef_omnibus: 12.18.31
   data_path: test/fixtures/keys
   data_bags_path: test/fixtures/data_bags
   attributes:
@@ -35,7 +39,7 @@ suites:
   # Smoke suite
   #
   - name: smoke_package_stable
-    run_list: jenkins_server_wrapper::default
+    run_list: jenkins_smoke::default
     attributes:
       jenkins:
         master:
@@ -44,7 +48,7 @@ suites:
       - ubuntu-14.04
       - debian-7.11
   - name: smoke_package_current
-    run_list: jenkins_server_wrapper::default
+    run_list: jenkins_smoke::default
     attributes:
       jenkins:
         master:
@@ -54,14 +58,14 @@ suites:
       - ubuntu-14.04
       - debian-7.11
   - name: smoke_war_stable
-    run_list: jenkins_server_wrapper::default
+    run_list: jenkins_smoke::default
     attributes:
       jenkins:
         master:
           install_method: war
           source: https://updates.jenkins.io/stable/latest/jenkins.war
   - name: smoke_war_latest
-    run_list: jenkins_server_wrapper::default
+    run_list: jenkins_smoke::default
     attributes:
       jenkins:
         master:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ env:
   matrix:
   - INSTANCE=smoke-package-stable-centos-7
   - INSTANCE=smoke-package-stable-ubuntu-1604
-  - INSTANCE=smoke-war-stable-centos-7
-  - INSTANCE=smoke-war-stable-ubuntu-1404
-  - INSTANCE=smoke-war-stable-ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -47,6 +47,9 @@ class Chef
     attribute :install_deps,
               kind_of: [TrueClass, FalseClass],
               default: true
+    attribute :ignore_deps_versions,
+              kind_of: [TrueClass, FalseClass],
+              default: false
     attribute :options,
               kind_of: String
 
@@ -125,7 +128,8 @@ EOH
             new_resource.name,
             new_resource.version,
             cli_opts: new_resource.options,
-            install_deps: new_resource.install_deps
+            install_deps: new_resource.install_deps,
+            ignore_deps_versions: new_resource.ignore_deps_versions
           )
         end
       end
@@ -277,7 +281,8 @@ EOH
             next
           elsif dep['optional'] == false
             # only install required dependencies
-            install_plugin_from_update_center(dep['name'], dep['version'], opts)
+            dep_version = opts[:ignore_deps_versions] ? :latest : dep['version']
+            install_plugin_from_update_center(dep['name'], dep_version, opts)
           end
         end
       end

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -67,7 +67,7 @@ end
 
 # Plugin required for Secret Text credentials
 jenkins_plugin 'plain-credentials' do
-  install_deps true
+  ignore_deps_versions true
   notifies :restart, 'service[jenkins]', :immediately
 end
 

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -2,7 +2,7 @@ require 'openssl'
 
 include_recipe 'jenkins_server_wrapper::default'
 
-fixture_data_base_path = '/tmp/kitchen/data'
+fixture_data_base_path = docker? ? '/opt/kitchen/data' : '/tmp/kitchen/data'
 
 # Test basic password credentials creation
 jenkins_password_credentials 'schisamo' do

--- a/test/fixtures/cookbooks/jenkins_server_wrapper/recipes/default.rb
+++ b/test/fixtures/cookbooks/jenkins_server_wrapper/recipes/default.rb
@@ -12,6 +12,7 @@ jenkins_plugins = %w(
 )
 jenkins_plugins.each do |plugin|
   jenkins_plugin plugin do
+    ignore_deps_versions true
     notifies :execute, 'jenkins_command[safe-restart]', :immediately
   end
 end

--- a/test/fixtures/cookbooks/jenkins_slave/recipes/create_ssh.rb
+++ b/test/fixtures/cookbooks/jenkins_slave/recipes/create_ssh.rb
@@ -50,6 +50,7 @@ credentials = jenkins_private_key_credentials 'jenkins-ssh-key' do
 end
 
 jenkins_password_credentials 'jenkins-ssh-password' do
+  id 'jenkins-ssh-password'
   password jenkins_user_data['password_clear']
 end
 

--- a/test/fixtures/cookbooks/jenkins_slave/recipes/create_ssh.rb
+++ b/test/fixtures/cookbooks/jenkins_slave/recipes/create_ssh.rb
@@ -1,5 +1,7 @@
 include_recipe 'jenkins_server_wrapper::default'
 
+return if docker? # SSH slave doesn't work in docker
+
 # Load user data from a data bag item. This should be an encrypted data
 # bag item in real deployments.
 jenkins_user_data = data_bag_item('keys', 'jenkins-ssh')

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -12,7 +12,7 @@ RSpec.configure do |config|
 end
 
 def fixture_data_base_path
-  '/tmp/kitchen/data'
+  docker? ? '/opt/kitchen/data' : '/tmp/kitchen/data'
 end
 
 def docker?

--- a/test/integration/jenkins_slave_create/serverspec/assert_ssh_created_spec.rb
+++ b/test/integration/jenkins_slave_create/serverspec/assert_ssh_created_spec.rb
@@ -1,56 +1,58 @@
 require 'spec_helper'
 
-#
-# SSH Slave #1
-# ------------------------------
-describe jenkins_slave('ssh-builder') do
-  it { should be_a_jenkins_slave }
-  it { should have_description('A builder, but over SSH') }
-  it { should have_remote_fs('/tmp/slave-ssh-builder') }
-  it { should have_labels(%w(builder linux)) }
-  it { should have_host('localhost') }
-  it { should have_port(22) }
-  it { should have_credentials('jenkins-ssh-key') }
-  it { should have_java_path('/usr/bin/java') }
-  it { should have_launch_timeout(30) }
-  it { should have_ssh_retries(5) }
-  it { should have_ssh_wait_retries(60) }
-  it { should be_connected }
-  it { should be_online }
-end
+describe 'SSH Slave', if: !docker? do
+  #
+  # SSH Slave #1
+  # ------------------------------
+  describe jenkins_slave('ssh-builder') do
+    it { should be_a_jenkins_slave }
+    it { should have_description('A builder, but over SSH') }
+    it { should have_remote_fs('/tmp/slave-ssh-builder') }
+    it { should have_labels(%w(builder linux)) }
+    it { should have_host('localhost') }
+    it { should have_port(22) }
+    it { should have_credentials('jenkins-ssh-key') }
+    it { should have_java_path('/usr/bin/java') }
+    it { should have_launch_timeout(30) }
+    it { should have_ssh_retries(5) }
+    it { should have_ssh_wait_retries(60) }
+    it { should be_connected }
+    it { should be_online }
+  end
 
-#
-# SSH Slave #2
-# ------------------------------
-describe jenkins_slave('ssh-executor') do
-  it { should be_a_jenkins_slave }
-  it { should have_description('An executor, but over SSH') }
-  it { should have_remote_fs('/tmp/slave-ssh-executor') }
-  it { should have_labels(%w(ssh-executor freebsd jail)) }
-  it { should have_host('localhost') }
-  it { should have_port(22) }
-  it { should have_credentials('38537014-ec66-49b5-aff2-aed1c19e2989') }
-  it { should have_launch_timeout(30) }
-  it { should have_ssh_retries(5) }
-  it { should have_ssh_wait_retries(60) }
-  it { should be_connected }
-  it { should be_online }
-end
+  #
+  # SSH Slave #2
+  # ------------------------------
+  describe jenkins_slave('ssh-executor') do
+    it { should be_a_jenkins_slave }
+    it { should have_description('An executor, but over SSH') }
+    it { should have_remote_fs('/tmp/slave-ssh-executor') }
+    it { should have_labels(%w(ssh-executor freebsd jail)) }
+    it { should have_host('localhost') }
+    it { should have_port(22) }
+    it { should have_credentials('38537014-ec66-49b5-aff2-aed1c19e2989') }
+    it { should have_launch_timeout(30) }
+    it { should have_ssh_retries(5) }
+    it { should have_ssh_wait_retries(60) }
+    it { should be_connected }
+    it { should be_online }
+  end
 
-#
-# SSH Slave #3
-# ------------------------------
-describe jenkins_slave('ssh-smoke') do
-  it { should be_a_jenkins_slave }
-  it { should have_description('A smoke tester, but over SSH') }
-  it { should have_remote_fs('/home/jenkins-ssh-password') }
-  it { should have_labels(%w(runner fast)) }
-  it { should have_host('localhost') }
-  it { should have_port(22) }
-  it { should have_credentials('jenkins-ssh-password') }
-  it { should have_launch_timeout(30) }
-  it { should have_ssh_retries(5) }
-  it { should have_ssh_wait_retries(60) }
-  it { should be_connected }
-  it { should be_online }
+  #
+  # SSH Slave #3
+  # ------------------------------
+  describe jenkins_slave('ssh-smoke') do
+    it { should be_a_jenkins_slave }
+    it { should have_description('A smoke tester, but over SSH') }
+    it { should have_remote_fs('/home/jenkins-ssh-password') }
+    it { should have_labels(%w(runner fast)) }
+    it { should have_host('localhost') }
+    it { should have_port(22) }
+    it { should have_credentials('jenkins-ssh-password') }
+    it { should have_launch_timeout(30) }
+    it { should have_ssh_retries(5) }
+    it { should have_ssh_wait_retries(60) }
+    it { should be_connected }
+    it { should be_online }
+  end
 end


### PR DESCRIPTION
### Description

This pull request reactivates the smoke tests that do more than just installing
Jenkins.
The slave creation tests had to be removed however, along with the war tests 
because of remaining issues with runit.
