### PR TITLE
Add "checksum" option for slave-jar remote_file resource

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -127,6 +127,15 @@ class Chef
     end
 
     #
+    # The checksum of the +slave.jar+.
+    #
+    # @return [String]
+    #
+    def slave_jar_checksum
+      @slave_jar_checksum ||= new_resource.checksum
+    end
+
+    #
     # The path to the +slave.jar+ on disk (which may or may not exist).
     #
     # @return [String]
@@ -211,6 +220,7 @@ class Chef
           build_resource(:remote_file, slave_jar).tap do |r|
             # We need to use .tap() to access methods in the provider's scope.
             r.source slave_jar_url
+            r.checksum slave_jar_checksum
             r.backup(false)
             r.mode('0755')
             r.atomic_update(false)


### PR DESCRIPTION
### Description

It is not a good practice to apply remote_file resource without
checksum.

### Issues Resolved

This commit will allow end user to add valid checksum value for slave.jar

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
