### PR TITLE
Add "checksum" attribute for JenkinsSlave resource

### DIFF
--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -75,6 +75,8 @@ class Chef
               kind_of: String
     attribute :java_path,
               kind_of: String
+    attribute :checksum,
+              kind_of: String
 
     attr_writer :exists
     attr_writer :connected


### PR DESCRIPTION
### Description

Without this attribute, an exception "NoMethodError" will be
raised when we call "new_resource.checksum" to declare remote_file
resource.

### Issues Resolved

Fix "NoMethodError" when call new_resource.checksum to build remote_file resource

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
