### PR TITLE
Fix ssh groovy

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -9,6 +9,8 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  client_rb:
+    chef_license: accept
 
 verifier:
   sudo: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,8 @@ provisioner:
         host: localhost
         install_method: war
         mirror: https://updates.jenkins.io
+  client_rb:
+    chef_license: accept
 
 platforms:
   - name: centos-6.9

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -139,8 +139,9 @@ module Jenkins
       file.write script
       file.flush
       @options[:prefix] = "cat #{file.path} |"
-      execute!("groovy =")
+      result = execute!("groovy =")
       @options.delete(:prefix)
+      return result
     ensure
       file.close! if file
     end
@@ -155,8 +156,9 @@ module Jenkins
       file.write script
       file.flush
       @options[:prefix] = "cat #{file.path} |"
-      execute("groovy =")
+      result = execute("groovy =")
       @options.delete(:prefix)
+      return result
     ensure
       file.close! if file
     end

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -69,8 +69,9 @@ module Jenkins
     def execute!(*pieces)
       command_options = pieces.last.is_a?(Hash) ? pieces.pop : {}
       command = []
+      command << %(#{options[:prefix]})                  if options[:prefix]
       command << %("#{options[:java]}")
-      command << options[:jvm_options].to_s if options[:jvm_options]
+      command << options[:jvm_options].to_s              if options[:jvm_options]
       command << %(-jar "#{options[:cli]}")
       command << %(-s #{URI.escape(options[:endpoint])}) if options[:endpoint]
       command << %(-#{options[:protocol]})               if options[:protocol]
@@ -122,7 +123,7 @@ module Jenkins
            Mixlib::ShellOut::CommandTimeout
       nil
     end
-
+    
     #
     # Execute the given inline groovy script, raising exceptions if something
     # fails.
@@ -137,7 +138,9 @@ module Jenkins
       file = Tempfile.new('groovy')
       file.write script
       file.flush
-      execute!("groovy #{file.path}")
+      @options[:prefix] = "cat #{file.path} |"
+      execute!("groovy =")
+      @options.delete(:prefix)
     ensure
       file.close! if file
     end
@@ -151,7 +154,9 @@ module Jenkins
       file = Tempfile.new('groovy')
       file.write script
       file.flush
-      execute("groovy #{file.path}")
+      @options[:prefix] = "cat #{file.path} |"
+      execute("groovy =")
+      @options.delete(:prefix)
     ensure
       file.close! if file
     end


### PR DESCRIPTION
### Description

When enable -ssh mode in CLI, groovy subcommand does not work. This is a known issue on jenkins side, see: https://issues.jenkins-ci.org/browse/JENKINS-41765

Using -ssh mode is a must-have to bump to latest LTS version of jenkins, as the -remoting mode is currently deperated and removed in version 2.165

### Issues Resolved

This fix pipes the groovy content to the CLI instead directly pass it through the argument, see jenkins jira link above

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
