### PR TITLE
Forward cookbook_name to remote_file resource

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -105,6 +105,7 @@ class Chef
       @slave_jar_resource.backup(false)
       @slave_jar_resource.mode('0777')
       @slave_jar_resource.atomic_update(false)
+      @slave_jar_resource.cookbook_name = new_resource.cookbook_name
       @slave_jar_resource
     end
 
@@ -137,6 +138,7 @@ class Chef
       @slave_exe_resource.source(new_resource.winsw_url)
       @slave_exe_resource.checksum(new_resource.winsw_checksum)
       @slave_exe_resource.backup(false)
+      @slave_exe_resource.cookbook_name = new_resource.cookbook_name
       @slave_exe_resource
     end
 


### PR DESCRIPTION
The JenkinsWindowsSlave provider is not using the DSL to instantiate the
'remote_file' resource. This means some creation steps are bypassed and
some attributes are not set (like 'cookbook_name', which is useful for us).

Other attributes will still be missing, I wanted this change to be as
small as possible but I can use the DSL if needed.

