### PR TITLE
[jenkins-windows-slave] Add direct_host attribute

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -49,6 +49,8 @@ class Chef
     attribute :pre_run_cmds,
               kind_of: Array,
               default: []
+    attribute :direct_host,
+              kind_of: String
   end
 end
 
@@ -201,6 +203,14 @@ class Chef
       @slave_xml_resource
     end
 
+    ##
+    # Return the direct host if it is passed as attribute
+    # Otherwise use the default jnlp_direct_host computed from groovy script.
+    def custom_end_host
+      return @custom_end_host ||= new_resource.direct_host unless new_resource.direct_host.empty?
+      return jnlp_direct_host
+    end
+
     #
     # Create bat file from jenkins-slave.bat.erb to launches Jenkins jar as
     # service. Optionally run any commands in :pre_run_cmds before launching jar
@@ -220,7 +230,7 @@ class Chef
         new_resource: new_resource,
         java_bin: java,
         slave_jar: slave_jar,
-        direct_host: jnlp_direct_host,
+        direct_host: custom_end_host,
         direct_port: jnlp_direct_port,
         instance_identity: instance_identity,
         jnlp_url: jnlp_url,


### PR DESCRIPTION
### Description

When Jenkins Master runs in a container (e.g. in rootless container with podman) the direct host is the internal address of the container and cannot be used to connect from the agents.

The is commit is a workaround allowing to provide the address to connect the agent directly to the master. In our context, the address of the container host.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
