### PR TITLE
[jenkins-windows-slave] Add property to use the conatiner host ip

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -132,7 +132,7 @@ class Chef
 
     def jnlp_direct_host
       return @jnlp_direct_host if @jnlp_direct_host
-      @jnlp_direct_host = executor.groovy "println(InetAddress.localHost.hostAddress)"
+      @jnlp_direct_host = executor.groovy 'println(System.getProperty("container.host.ip", InetAddress.localHost.hostAddress))'
     end
 
     def jnlp_direct_port


### PR DESCRIPTION
### Description
A java property can be used to define the direct ip address of the master

### Issues Resolved
A master runs in container returns the container address instead of the container host

### Check List
None
