### PR TITLE
Re-use attributes to determine java setup

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -374,15 +374,7 @@ If this problem persists, check your Jenkins log files.
     # @return [String]
     #
     def java
-      if node['java'] && node['java']['java_home']
-        File.join(node['java']['java_home'], 'bin', 'java')
-      elsif node['java'] && node['java']['home']
-        File.join(node['java']['home'], 'bin', 'java')
-      elsif ENV['JAVA_HOME']
-        File.join(ENV['JAVA_HOME'], 'bin', 'java')
-      else
-        'java'
-      end
+      node['jenkins']['java']
     end
 
     #


### PR DESCRIPTION
* This is basically a revert of 43a10b68831ec9c6045097c9edf4631670ce5591
* This attribute was the only way to explicitly override the java path used to start 
* We understood the issues we had with our policies essentially come from how we used (or not) the java cookbook. So this is on this side that we should work and ensure the java path is correct at the end.