### PR TITLE
launch Exec command with bash -l to benefit the environment

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -379,7 +379,7 @@ class Chef
           Environment="HOME=#{new_resource.remote_fs}"
           Environment="JENKINS_HOME=#{new_resource.remote_fs}"
           WorkingDirectory=#{new_resource.remote_fs}
-          ExecStart=#{exec_string}
+          ExecStart=/bin/bash -lc "#{exec_string}"
 
           [Install]
           WantedBy=multi-user.target


### PR DESCRIPTION
  The user command is launched without proper environment variables.
  With this modification, the user environment is set before launching the Exec command