### PR TITLE
Fix chef18 compatibility issues

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -98,14 +98,13 @@ class Chef
       end
 
       service_name = new_resource.use_systemd ? "systemd_unit[#{new_resource.service_name}.service]" : "runit_service[#{new_resource.service_name}]"
-
-      declare_resource(:remote_file, slave_jar).tap do |r|
-        # We need to use .tap() to access methods in the provider's scope.
-        r.source slave_jar_url
-        r.backup(false)
-        r.mode('0755')
-        r.atomic_update(false)
-        r.notifies :restart, service_name unless platform?('windows')
+      u = slave_jar_url
+      declare_resource(:remote_file, slave_jar) do
+        source(u)
+        backup(false)
+        mode('0755')
+        atomic_update(false)
+        notifies :restart, service_name unless platform?('windows')
       end
 
       # The Windows's specific child class manages it's own service

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -325,28 +325,6 @@ class Chef
     end
 
     def create_with_systemd
-      # disable runit services before starting new service
-      # TODO: remove in future version
-
-      %W(
-        /etc/init.d/#{new_resource.service_name}
-        /etc/service/#{new_resource.service_name}
-      ).each do |f|
-        file f do
-          action :delete
-          notifies :stop, "service[#{new_resource.service_name}]", :before
-        end
-      end
-
-      # runit_service = if platform_family?('debian')
-      #                   'runit'
-      #                 else
-      #                   'runsvdir-start'
-      #                 end
-      # service runit_service do
-      #   action [:stop, :disable]
-      # end
-
       exec_string = "#{java} #{new_resource.jvm_options}"
       exec_string << " -cp #{slave_jar} hudson.remoting.jnlp.Main"
       exec_string << ' -headless'


### PR DESCRIPTION
This PR backports the following commit from master branch, not yet in mainline-criteo:
https://github.com/criteo-forks/jenkins/commit/906ecf267734fe6c632048501a2f484f8fcce457

The fixes are needed for Chef 18 compatibility. They have been tested in kitchen for both Chef 17 and Chef 18.
