### PR TITLE
✨ Support Vault Approle credentials type

### DIFF
--- a/documentation/jenkins_vault_app_role_credentials.md
+++ b/documentation/jenkins_vault_app_role_credentials.md
@@ -1,0 +1,68 @@
+# jenkins_vault_app_role_credentials
+
+HashiCorp Vault App Role credentials for the `hashicorp-vault-plugin`. This credential type allows Jenkins to authenticate with Vault using the AppRole authentication method.
+
+## Requirements
+
+Requires the `hashicorp-vault-plugin` to be installed on your Jenkins instance.
+
+## Examples
+
+```ruby
+# Create Vault App Role credentials
+jenkins_vault_app_role_credentials 'vault-approle' do
+  id          'vault-approle-creds'
+  description 'Vault AppRole credentials for Jenkins'
+  role_id     'my-role-id'
+  secret_id   'my-secret-id'
+  path        'approle'  # Optional, defaults to 'approle'
+end
+```
+
+```ruby
+# Create Vault App Role credentials with custom path
+jenkins_vault_app_role_credentials 'vault-jenkins' do
+  id          'vault-jenkins-creds'
+  description 'Vault AppRole credentials with custom path'
+  role_id     'jenkins-role-id'
+  secret_id   'jenkins-secret-id'
+  path        'jenkins'
+end
+```
+
+```ruby
+# Delete Vault App Role credentials
+jenkins_vault_app_role_credentials 'vault-approle' do
+  id     'vault-approle-creds'
+  action :delete
+end
+```
+
+## Properties
+
+- **id** - (required) The unique identifier for the credential. If not specified, a UUID will be generated.
+- **description** - (optional) A human-readable description of the credential.
+- **role_id** - (required) The Role ID used for AppRole authentication with Vault.
+- **secret_id** - (required) The Secret ID used for AppRole authentication with Vault.
+- **path** - (optional) The AppRole authentication mount path in Vault. Defaults to `'approle'`.
+
+## About AppRole Authentication
+
+AppRole is a Vault authentication method that is specifically designed for machine-to-machine authentication. It uses a `role_id` (similar to a username) and a `secret_id` (similar to a password) to authenticate.
+
+When registering an AppRole auth backend in Vault, you can configure:
+- How long the `secret_id` should live (can be indefinite)
+- How often a token obtained via this backend can be used
+- Which IP addresses can obtain a token using the `role_id` and `secret_id`
+- And many more options
+
+For more information, see the [HashiCorp Vault AppRole documentation](https://www.vaultproject.io/docs/auth/approle.html).
+
+## Scopes
+
+Credentials in Jenkins can be created with 2 different "scopes" which determines where the credentials can be used:
+
+- **GLOBAL** - This credential is available to the object on which the credential is associated and all objects that are children of that object. Typically you would use global-scoped credentials for things that are needed by jobs.
+- **SYSTEM** - This credential is only available to the object on which the credential is associated. Typically you would use system-scoped credentials for things like email auth, slave connection, etc, i.e. where the Jenkins instance itself is using the credential. Unlike the global scope, this significantly restricts where the credential can be used, thereby providing a higher degree of confidentiality to the credential.
+
+The credentials created with the `jenkins_vault_app_role_credentials` resource are assigned a `GLOBAL` scope.

--- a/documentation/jenkins_vault_app_role_credentials.md
+++ b/documentation/jenkins_vault_app_role_credentials.md
@@ -15,18 +15,20 @@ jenkins_vault_app_role_credentials 'vault-approle' do
   description 'Vault AppRole credentials for Jenkins'
   role_id     'my-role-id'
   secret_id   'my-secret-id'
-  path        'approle'  # Optional, defaults to 'approle'
+  path        'approle'     # Optional, defaults to 'approle'
+  use_policies true         # Optional, defaults to true
 end
 ```
 
 ```ruby
 # Create Vault App Role credentials with custom path
 jenkins_vault_app_role_credentials 'vault-jenkins' do
-  id          'vault-jenkins-creds'
-  description 'Vault AppRole credentials with custom path'
-  role_id     'jenkins-role-id'
-  secret_id   'jenkins-secret-id'
-  path        'jenkins'
+  id           'vault-jenkins-creds'
+  description  'Vault AppRole credentials with custom path'
+  role_id      'jenkins-role-id'
+  secret_id    'jenkins-secret-id'
+  path         'jenkins'
+  use_policies true
 end
 ```
 
@@ -45,6 +47,7 @@ end
 - **role_id** - (required) The Role ID used for AppRole authentication with Vault.
 - **secret_id** - (required) The Secret ID used for AppRole authentication with Vault.
 - **path** - (optional) The AppRole authentication mount path in Vault. Defaults to `'approle'`.
+- **use_policies** - (optional) Enable the "Limit Token Policies" option. When enabled, allows isolating policies for different jobs. Defaults to `true`.
 
 ## About AppRole Authentication
 
@@ -57,6 +60,21 @@ When registering an AppRole auth backend in Vault, you can configure:
 - And many more options
 
 For more information, see the [HashiCorp Vault AppRole documentation](https://www.vaultproject.io/docs/auth/approle.html).
+
+## Isolating Policies for Different Jobs
+
+The `use_policies` attribute enables the "Limit Token Policies" feature. When enabled, it allows you to isolate Vault policies for different Jenkins jobs or folders. 
+
+The process works as follows:
+1. The Jenkins job attempts to retrieve a secret from Vault
+2. The AppRole authentication is used to retrieve a new token (if not expired)
+3. The Vault plugin uses the `policies` configuration value with job info to determine a list of policies
+4. If this list is not empty and `use_policies` is enabled, the AppRole token is used to retrieve a new token with only the specified policies applied
+5. This token is then used for all Vault plugin operations in the job
+
+**Note**: The AppRole (or other authentication method) should have all policies configured as `token_policies` and not `identity_policies`, as job-specific tokens inherit all `identity_policies` automatically.
+
+For more information about this feature, see the [HashiCorp Vault plugin documentation on isolating policies](https://plugins.jenkins.io/hashicorp-vault-plugin/#isolating-policies-for-different-jobs).
 
 ## Scopes
 

--- a/libraries/credentials_vault_app_role.rb
+++ b/libraries/credentials_vault_app_role.rb
@@ -1,0 +1,134 @@
+#
+# Cookbook:: jenkins
+# Resource:: credentials_vault_app_role
+#
+# Author:: Guillaume Monceyron <g.monceyron@criteo.com>
+#
+# Copyright:: 2026, Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'credentials'
+
+class Chef
+  class Resource::JenkinsVaultAppRoleCredentials < Resource::JenkinsCredentials
+    resource_name :jenkins_vault_app_role_credentials # Still needed for Chef 15 and below
+    provides :jenkins_vault_app_role_credentials
+
+    # Chef attributes
+    identity_attr :description
+
+    # Attributes
+    attribute :description,
+              kind_of: String
+    attribute :role_id,
+              kind_of: String,
+              required: true
+    attribute :secret_id,
+              kind_of: String,
+              required: true
+    attribute :path,
+              kind_of: String,
+              default: 'approle'
+  end
+end
+
+class Chef
+  class Provider::JenkinsVaultAppRoleCredentials < Provider::JenkinsCredentials
+    provides :jenkins_vault_app_role_credentials
+
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsVaultAppRoleCredentials.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.role_id(current_credentials[:role_id])
+        @current_resource.secret_id(current_credentials[:secret_id])
+        @current_resource.path(current_credentials[:path])
+      end
+
+      @current_resource
+    end
+
+    private
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#credentials_groovy
+    # @see https://github.com/jenkinsci/hashicorp-vault-plugin/blob/master/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
+    #
+    def credentials_groovy
+      <<-EOH.gsub(/^ {8}/, '')
+        import hudson.util.Secret
+        import com.cloudbees.plugins.credentials.CredentialsScope
+        import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential
+
+        credentials = new VaultAppRoleCredential(
+          CredentialsScope.GLOBAL,
+          #{convert_to_groovy(new_resource.id)},
+          #{convert_to_groovy(new_resource.description)},
+          #{convert_to_groovy(new_resource.role_id)},
+          Secret.fromString(#{convert_to_groovy(new_resource.secret_id)}),
+          #{convert_to_groovy(new_resource.path)}
+        )
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#fetch_credentials_groovy
+    #
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      <<-EOH.gsub(/^ {8}/, '')
+        #{credentials_for_id_groovy(new_resource.id, groovy_variable_name)}
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#resource_attributes_groovy
+    #
+    def resource_attributes_groovy(groovy_variable_name)
+      <<-EOH.gsub(/^ {8}/, '')
+        #{groovy_variable_name} = [
+          id:credentials.id,
+          description:credentials.description,
+          role_id:credentials.roleId,
+          secret_id:credentials.secretId,
+          path:credentials.path
+        ]
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#attribute_to_property_map
+    #
+    def attribute_to_property_map
+      { secret_id: 'credentials.secretId.plainText' }
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#correct_config?
+    #
+    def correct_config?
+      wanted_credentials = {
+        description: new_resource.description,
+        role_id: new_resource.role_id,
+        secret_id: new_resource.secret_id,
+        path: new_resource.path,
+      }
+
+      # Don't compare the ID as it is generated
+      current_credentials.dup.tap { |c| c.delete(:id) } == convert_blank_values_to_nil(wanted_credentials)
+    end
+  end
+end

--- a/libraries/credentials_vault_app_role.rb
+++ b/libraries/credentials_vault_app_role.rb
@@ -41,6 +41,9 @@ class Chef
     attribute :path,
               kind_of: String,
               default: 'approle'
+    attribute :use_policies,
+              kind_of: [TrueClass, FalseClass],
+              default: true
   end
 end
 
@@ -57,6 +60,7 @@ class Chef
         @current_resource.role_id(current_credentials[:role_id])
         @current_resource.secret_id(current_credentials[:secret_id])
         @current_resource.path(current_credentials[:path])
+        @current_resource.use_policies(current_credentials[:use_policies])
       end
 
       @current_resource
@@ -82,6 +86,7 @@ class Chef
           Secret.fromString(#{convert_to_groovy(new_resource.secret_id)}),
           #{convert_to_groovy(new_resource.path)}
         )
+        credentials.setUsePolicies(#{new_resource.use_policies})
       EOH
     end
 
@@ -104,7 +109,8 @@ class Chef
           description:credentials.description,
           role_id:credentials.roleId,
           secret_id:credentials.secretId,
-          path:credentials.path
+          path:credentials.path,
+          use_policies:credentials.usePolicies
         ]
       EOH
     end
@@ -125,6 +131,7 @@ class Chef
         role_id: new_resource.role_id,
         secret_id: new_resource.secret_id,
         path: new_resource.path,
+        use_policies: new_resource.use_policies,
       }
 
       # Don't compare the ID as it is generated


### PR DESCRIPTION
This aims at supporting credentials management for the Vault Approle type that is provided by the Jenkins Hashicorp Vault plugins.

See https://plugins.jenkins.io/hashicorp-vault-plugin/

JIRA: BUILD-3082