### PR TITLE
✨ Support Vault Secret Text credentials type

### DIFF
--- a/documentation/jenkins_vault_text_secret_credentials.md
+++ b/documentation/jenkins_vault_text_secret_credentials.md
@@ -1,0 +1,56 @@
+# jenkins_vault_text_secret_credentials
+
+Vault Text Secret credentials for the `hashicorp-vault-plugin`. This credential type lets Jenkins expose a single text value read from a HashiCorp Vault KV secret.
+
+## Requirements
+
+Requires the `hashicorp-vault-plugin` to be installed on your Jenkins instance.
+
+## Examples
+
+```ruby
+# Create Vault Text Secret credentials
+jenkins_vault_text_secret_credentials 'vault-password' do
+  id 'vault-password'
+  description 'Password read from Vault'
+  path 'secret/jenkins/passwords'
+  vault_key 'password'
+end
+
+# Create Vault Text Secret credentials with all Vault lookup options
+jenkins_vault_text_secret_credentials 'namespaced-vault-password' do
+  id 'namespaced-vault-password'
+  description 'Password read from a namespaced Vault mount'
+  path 'secret/jenkins/passwords'
+  prefix_path 'kv'
+  namespace 'admin'
+  engine_version 2
+  vault_key 'password'
+end
+
+# Delete Vault Text Secret credentials
+jenkins_vault_text_secret_credentials 'vault-password' do
+  id 'vault-password'
+  path 'secret/jenkins/passwords'
+  action :delete
+end
+```
+
+## Properties
+
+- **id** - (required) The unique identifier for the credential.
+- **description** - (optional) A human-readable description of the credential.
+- **path** - (required) The Vault secret path to read.
+- **prefix_path** - (optional) A Vault path prefix for installations using prefixed KV mounts.
+- **namespace** - (optional) The Vault namespace.
+- **engine_version** - (optional) The Vault KV engine version. Defaults to `2`.
+- **vault_key** - (optional) The key inside the Vault secret. Defaults to `'secret'`.
+
+## Scopes
+
+Credentials in Jenkins can be created with 2 different "scopes" which determines where the credentials can be used:
+
+- **GLOBAL** - This credential is available to the object on which the credential is associated and all objects that are children of that object. Typically you would use global-scoped credentials for things that are needed by jobs.
+- **SYSTEM** - This credential is only available to the object on which the credential is associated. Typically you would use system-scoped credentials for things like email auth, slave connection, etc, i.e. where the Jenkins instance itself is using the credential. Unlike the global scope, this significantly restricts where the credential can be used, thereby providing a higher degree of confidentiality to the credential.
+
+The credentials created with the `jenkins_vault_text_secret_credentials` resource are assigned a `GLOBAL` scope.

--- a/libraries/credentials_vault_text_secret.rb
+++ b/libraries/credentials_vault_text_secret.rb
@@ -1,0 +1,162 @@
+#
+# Cookbook:: jenkins
+# Resource:: credentials_vault_text_secret
+#
+# Author:: Guillaume Monceyron <g.monceyron@criteo.com>
+#
+# Copyright:: 2026, Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'credentials'
+
+class Chef
+  class Resource::JenkinsVaultTextSecretCredentials < Resource::JenkinsCredentials
+    resource_name :jenkins_vault_text_secret_credentials # Still needed for Chef 15 and below
+    provides :jenkins_vault_text_secret_credentials
+
+    # Chef attributes
+    identity_attr :description
+
+    # Attributes
+    attribute :description,
+              kind_of: String
+    attribute :path,
+              kind_of: String,
+              required: true
+    attribute :prefix_path,
+              kind_of: String
+    attribute :namespace,
+              kind_of: String
+    attribute :engine_version,
+              kind_of: Integer,
+              equal_to: [1, 2],
+              default: 2
+    attribute :vault_key,
+              kind_of: String,
+              default: 'secret'
+  end
+end
+
+class Chef
+  class Provider::JenkinsVaultTextSecretCredentials < Provider::JenkinsCredentials
+    provides :jenkins_vault_text_secret_credentials
+
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsVaultTextSecretCredentials.new(new_resource.name)
+
+      super
+
+      if current_credentials
+        @current_resource.path(current_credentials[:path])
+        @current_resource.prefix_path(current_credentials[:prefix_path])
+        @current_resource.namespace(current_credentials[:namespace])
+        @current_resource.engine_version(current_credentials[:engine_version])
+        @current_resource.vault_key(current_credentials[:vault_key])
+      end
+
+      @current_resource
+    end
+
+    private
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#credentials_groovy
+    # @see https://github.com/jenkinsci/hashicorp-vault-plugin/blob/master/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+    #
+    def credentials_groovy
+      <<-EOH.gsub(/^ {8}/, '')
+        import com.cloudbees.plugins.credentials.CredentialsScope
+        import com.datapipe.jenkins.vault.credentials.common.VaultStringCredentialImpl
+
+        credentials = new VaultStringCredentialImpl(
+          CredentialsScope.GLOBAL,
+          #{convert_to_groovy(new_resource.id)},
+          #{convert_to_groovy(new_resource.description)}
+        )
+        credentials.setPath(#{convert_to_groovy(new_resource.path)})
+        credentials.setVaultKey(#{convert_to_groovy(new_resource.vault_key)})
+        credentials.setEngineVersion(#{convert_to_groovy(new_resource.engine_version)})
+        #{optional_setter_groovy('setPrefixPath', new_resource.prefix_path)}
+        #{optional_setter_groovy('setNamespace', new_resource.namespace)}
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#fetch_credentials_groovy
+    #
+    def fetch_existing_credentials_groovy(groovy_variable_name)
+      <<-EOH.gsub(/^ {8}/, '')
+        import jenkins.model.Jenkins
+        import com.cloudbees.plugins.credentials.CredentialsMatchers
+        import com.cloudbees.plugins.credentials.CredentialsProvider
+        import com.cloudbees.plugins.credentials.common.IdCredentials
+
+        id_matcher = CredentialsMatchers.withId(#{convert_to_groovy(new_resource.id)})
+        available_credentials =
+          CredentialsProvider.lookupCredentials(
+            IdCredentials.class,
+            Jenkins.getInstance(),
+            hudson.security.ACL.SYSTEM
+          )
+
+        #{groovy_variable_name} =
+          CredentialsMatchers.firstOrNull(
+            available_credentials,
+            id_matcher
+          )
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#resource_attributes_groovy
+    #
+    def resource_attributes_groovy(groovy_variable_name)
+      <<-EOH.gsub(/^ {8}/, '')
+        #{groovy_variable_name} = [
+          id:credentials.id,
+          description:credentials.description,
+          path:credentials.path,
+          prefix_path:credentials.prefixPath,
+          namespace:credentials.namespace,
+          engine_version:credentials.engineVersion,
+          vault_key:credentials.vaultKey
+        ]
+      EOH
+    end
+
+    #
+    # @see Chef::Resource::JenkinsCredentials#correct_config?
+    #
+    def correct_config?
+      wanted_credentials = {
+        description: new_resource.description,
+        path: new_resource.path,
+        prefix_path: new_resource.prefix_path,
+        namespace: new_resource.namespace,
+        engine_version: new_resource.engine_version,
+        vault_key: new_resource.vault_key,
+      }
+
+      # Don't compare the ID as it is generated
+      current_credentials.dup.tap { |c| c.delete(:id) } == convert_blank_values_to_nil(wanted_credentials)
+    end
+
+    def optional_setter_groovy(setter, value)
+      return if value.nil?
+
+      "credentials.#{setter}(#{convert_to_groovy(value)})"
+    end
+  end
+end

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/create.rb
@@ -71,10 +71,27 @@ jenkins_plugin 'plain-credentials' do
   notifies :restart, 'service[jenkins]', :immediately
 end
 
+# Plugin required for Vault Text Secret credentials
+jenkins_plugin 'hashicorp-vault-plugin' do
+  install_deps true
+  notifies :restart, 'service[jenkins]', :immediately
+end
+
 # Test creating a secret text with a dollar sign in it
 jenkins_secret_text_credentials 'dollarbills_secret' do
   id 'dollarbills_secret'
   secret '$uper$ecret'
+end
+
+# Test creating a Vault text secret
+jenkins_vault_text_secret_credentials 'vault_text_secret' do
+  id 'vault_text_secret'
+  description 'Vault text secret'
+  path 'secret/jenkins/passwords'
+  prefix_path 'kv'
+  namespace 'admin'
+  engine_version 2
+  vault_key 'password'
 end
 
 # Test creating a file credentials

--- a/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
+++ b/test/fixtures/cookbooks/jenkins_credentials/recipes/delete.rb
@@ -59,6 +59,14 @@ jenkins_secret_text_credentials 'secret_text_credentials_to_delete' do
   action [:create, :delete]
 end
 
+jenkins_vault_text_secret_credentials 'vault_text_secret_to_delete' do
+  id 'vault_text_secret_to_delete'
+  path 'secret/jenkins/passwords'
+  vault_key 'password'
+
+  action [:create, :delete]
+end
+
 jenkins_file_credentials 'file_to_delete' do
   id 'file_to_delete'
   filename 'file_to_delete'

--- a/test/integration/helpers/jenkins_inspec/libraries/jenkins_credentials.rb
+++ b/test/integration/helpers/jenkins_inspec/libraries/jenkins_credentials.rb
@@ -113,3 +113,51 @@ class JenkinsSecretTextCredentials < JenkinsCredentials
     @xml = nil
   end
 end
+
+class JenkinsVaultTextSecretCredentials < JenkinsCredentials
+  attr_reader :credential_id
+
+  name 'jenkins_vault_text_secret_credentials'
+
+  def initialize(credential_id)
+    @credential_id = credential_id
+  end
+
+  def description
+    try { xml.elements['description'].text }
+  end
+
+  def path
+    try { xml.elements['path'].text }
+  end
+
+  def prefix_path
+    try { xml.elements['prefixPath'].text }
+  end
+
+  def namespace
+    try { xml.elements['namespace'].text }
+  end
+
+  def engine_version
+    try { xml.elements['engineVersion'].text.to_i }
+  end
+
+  def vault_key
+    try { xml.elements['vaultKey'].text }
+  end
+
+  def to_s
+    "Jenkins Vault Text Secret Credentials #{credential_id}"
+  end
+
+  private
+
+  def xml
+    return @xml if @xml
+
+    @xml = REXML::XPath.first(doc, "//*[id/text() = '#{credential_id}' and scope/text() = 'GLOBAL']/")
+  rescue Errno::ENOENT
+    @xml = nil
+  end
+end

--- a/test/integration/jenkins_smoke/controls/jenkins_credentials.rb
+++ b/test/integration/jenkins_smoke/controls/jenkins_credentials.rb
@@ -76,6 +76,21 @@ control 'jenkins_credentials-3.0' do
   end
 end
 
+control 'jenkins_credentials-3.1' do
+  impact 0.7
+  title 'Jenkins Vault Text Secret Credentials are created'
+
+  describe jenkins_vault_text_secret_credentials('vault_text_secret') do
+    it { should exist }
+    its('description') { should eq 'Vault text secret' }
+    its('path') { should eq 'secret/jenkins/passwords' }
+    its('prefix_path') { should eq 'kv' }
+    its('namespace') { should eq 'admin' }
+    its('engine_version') { should eq 2 }
+    its('vault_key') { should eq 'password' }
+  end
+end
+
 control 'jenkins_credentials-4.0' do
   impact 0.7
   title 'Jenkins Users Credentials are deleted'
@@ -98,6 +113,10 @@ control 'jenkins_credentials-5.0' do
   end
 
   describe jenkins_secret_text_credentials('secret_text_credentials_to_delete') do
+    it { should_not exist }
+  end
+
+  describe jenkins_vault_text_secret_credentials('vault_text_secret_to_delete') do
     it { should_not exist }
   end
 end


### PR DESCRIPTION
This aims at supporting credentials management for the Vault Secret text type that is provided by the Jenkins Hashicorp Vault plugin.

See https://plugins.jenkins.io/hashicorp-vault-plugin/

JIRA: BUILD-3159